### PR TITLE
Add VPA for snapshot-controller and snapshot-validation-deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add team label in resources.
 - Add toleration for new control-plane taint.
+- Add VPA for `snapshot-controller` and `snapshot-validation-deployment` Deployments.
 
 ### Changed
 
@@ -18,17 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] - 2022-10-11
 
-### Changed
+### Changed
 - Fix `crd-install` job by using right folder name.
 - Add new configuration interface to create default `VolumeSnapshotClass`.
 
 ## [0.2.0] - 2022-05-23
 
-### Added
+### Added
 
 - Add validating webhook.
   
-### Changed
+### Changed
 
 - Update manifests with upstream `v5.0.1`.
 - Use `kustomize` for templating upstream manifests without manual editing.

--- a/helm/csi-external-snapshotter-app/templates/vpa.yaml
+++ b/helm/csi-external-snapshotter-app/templates/vpa.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.verticalPodAutoscaler.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: snapshot-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: snapshot-controller
+  updatePolicy:
+    updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+    {{- toYaml .Values.verticalPodAutoscaler.snapshotController.containerPolicies | nindent 4 }}
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: snapshot-validation-deployment
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: snapshot-validation-deployment
+  updatePolicy:
+    updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+    {{- toYaml .Values.verticalPodAutoscaler.validationWebhook.containerPolicies | nindent 4 }}
+{{- end }}

--- a/helm/csi-external-snapshotter-app/values.schema.json
+++ b/helm/csi-external-snapshotter-app/values.schema.json
@@ -88,6 +88,30 @@
                     "type": "string"
                 }
             }
+        },
+        "verticalPodAutoscaler": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "snapshotController": {
+                    "type": "object",
+                    "properties": {
+                        "containerPolicies": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "validationWebhook": {
+                    "type": "object",
+                    "properties": {
+                        "containerPolicies": {
+                            "type": "array"
+                        }
+                    }
+                }
+            }
         }
     },
     "required": [

--- a/helm/csi-external-snapshotter-app/values.yaml
+++ b/helm/csi-external-snapshotter-app/values.yaml
@@ -25,3 +25,16 @@ defaults:
     create: false
     name: ""
     driver: ""
+
+verticalPodAutoscaler:
+  enabled: true
+  snapshotController:
+    containerPolicies:
+      - containerName: snapshot-controller
+        controlledValues: RequestsAndLimits
+        mode: Auto
+  validationWebhook:
+    containerPolicies:
+      - containerName: snapshot-validation
+        controlledValues: RequestsAndLimits
+        mode: Auto


### PR DESCRIPTION
## What

Adds `VerticalPodAutoscaler` resources for both Deployments managed by this chart:
- `snapshot-controller`
- `snapshot-validation-deployment`

VPA is enabled by default (`verticalPodAutoscaler.enabled: true`) and can be disabled via values.

## Why

The  engineering team identified `snapshot-controller` as a component running without VPA on their production clusters, during a resource usage assessment (2026-02-03). This was tracked in giantswarm/giantswarm#35769.

Both workloads are Deployments, so VPA `updateMode: Auto` is fully supported — VPA can freely evict and resize pods. Using `controlledValues: RequestsAndLimits` ensures both requests and limits are kept in sync, preventing the limits from diverging after VPA adjusts requests.

## Changes

- `templates/vpa.yaml` — new file, two VPA resources
- `values.yaml` — added `verticalPodAutoscaler` section with default container policies
- `values.schema.json` — schema for the new values